### PR TITLE
Move commands may move the Victim not the player who typed the command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ src/game/generated
 SDL.dll
 autoexec.cfg
 
+banmaster
+banmaster_*
 crapnet*
 dilate*
 fake_server*

--- a/src/game/server/ddracecommands.cpp
+++ b/src/game/server/ddracecommands.cpp
@@ -47,7 +47,7 @@ void CGameContext::ConMoveRaw(IConsole::IResult *pResult, void *pUserData, int C
 
 void CGameContext::MoveCharacter(int ClientID, int Victim, int X, int Y, bool Raw)
 {
-	CCharacter* pChr = GetPlayerChar(ClientID);
+	CCharacter* pChr = GetPlayerChar(Victim);
 
 	if(!pChr)
 		return;


### PR DESCRIPTION
move/up/down/... commands may move the victim, not the one who typed the command.
I also added banmaster binary to .gitignore
