### PR TITLE
return from afk handling code immediately if player got kicked, as player

### DIFF
--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -143,7 +143,7 @@ public:
 
 	int m_ChatScore;
 
-	void AfkTimer(int new_target_x, int new_target_y);
+	bool AfkTimer(int new_target_x, int new_target_y); //returns true if kicked
 	int64 m_LastPlaytime;
 	int m_LastTarget_x;
 	int m_LastTarget_y;


### PR DESCRIPTION
it always [segfaults](http://pastie.org/1842616) when someone is kicked for being afk, because it tries to access m_pGameserver field of player struct which was [zeroed out earlier](http://pastie.org/1842612) during kick process
