### PR TITLE
Adding vote to force-pause players (instead of just moving them to spectators).

### DIFF
--- a/src/game/ddracecommands.h
+++ b/src/game/ddracecommands.h
@@ -40,6 +40,8 @@ CONSOLE_COMMAND("help", "?r", CFGFLAG_SERVER, ConHelp, this, "Shows help to comm
 CONSOLE_COMMAND("info", "", CFGFLAG_SERVER, ConInfo, this, "Shows info about this server", IConsole::CONSOLELEVEL_USER)
 CONSOLE_COMMAND("me", "r", CFGFLAG_SERVER, ConMe, this, "Like the famous irc command '/me says hi' will display '<yourname> says hi'", IConsole::CONSOLELEVEL_USER)
 CONSOLE_COMMAND("pause", "", CFGFLAG_SERVER, ConTogglePause, this, "Toggles pause on/off (if activated on server)", IConsole::CONSOLELEVEL_USER)
+CONSOLE_COMMAND("force_pause", "v?i", CFGFLAG_SERVER, ConForcePause, this, "Force v to pause for i seconds", IConsole::CONSOLELEVEL_ADMIN)
+CONSOLE_COMMAND("force_unpause", "v", CFGFLAG_SERVER, ConForceUnpause, this, "Force v to unpause", IConsole::CONSOLELEVEL_ADMIN)
 CONSOLE_COMMAND("rank", "?r", CFGFLAG_SERVER, ConRank, this, "Shows the rank of player with name r (your rank by default)", IConsole::CONSOLELEVEL_USER)
 CONSOLE_COMMAND("rules", "", CFGFLAG_SERVER, ConRules, this, "Shows the server rules", IConsole::CONSOLELEVEL_USER)
 CONSOLE_COMMAND("team", "?i", CFGFLAG_SERVER, ConJoinTeam, this, "Lets you join team i (shows your team if left blank)", IConsole::CONSOLELEVEL_USER)

--- a/src/game/server/ddracecommands.cpp
+++ b/src/game/server/ddracecommands.cpp
@@ -467,26 +467,26 @@ void CGameContext::ConTogglePause(IConsole::IResult *pResult, void *pUserData, i
 	if(g_Config.m_SvPauseable)
 	{
 		CCharacter* pChr = pPlayer->GetCharacter();
-		if(!pPlayer->GetTeam() && pChr && (!pChr->GetWeaponGot(WEAPON_NINJA) || pChr->m_FreezeTime) && pChr->IsGrounded() && pChr->m_Pos==pChr->m_PrevPos && !pChr->Team() && !pPlayer->m_InfoSaved)
+		if(!pPlayer->GetTeam() && pChr && (!pChr->GetWeaponGot(WEAPON_NINJA) || pChr->m_FreezeTime) && pChr->IsGrounded() && pChr->m_Pos==pChr->m_PrevPos && !pPlayer->m_InfoSaved)
 		{
 			if(pPlayer->m_LastSetTeam + pSelf->Server()->TickSpeed() * g_Config.m_SvPauseFrequency <= pSelf->Server()->Tick())
 			{
 				pPlayer->SaveCharacter();
-				pPlayer->SetTeam(TEAM_SPECTATORS);
 				pPlayer->m_InfoSaved = true;
+				pPlayer->SetTeam(TEAM_SPECTATORS);
 			}
 			else
 				pResult->Print(IConsole::OUTPUT_LEVEL_STANDARD, "info", "You can\'t pause that often.");
 		}
 		else if(pPlayer->GetTeam()==TEAM_SPECTATORS && pPlayer->m_InfoSaved && pPlayer->m_ForcePauseTime==0)
 		{
-			pPlayer->m_InfoSaved = false;
 			pPlayer->m_PauseInfo.m_Respawn = true;
 			pPlayer->SetTeam(TEAM_RED);
+			pPlayer->m_InfoSaved = false;
 			//pPlayer->LoadCharacter();//TODO:Check if this system Works
 		}
 		else if(pChr)
-			pResult->Print(IConsole::OUTPUT_LEVEL_STANDARD, "info", (pChr->Team())?"You can't pause while you are in a team":pChr->GetWeaponGot(WEAPON_NINJA)?"You can't use /pause while you are a ninja":(!pChr->IsGrounded())?"You can't use /pause while you are a in air":"You can't use /pause while you are moving");
+			pResult->Print(IConsole::OUTPUT_LEVEL_STANDARD, "info", pChr->GetWeaponGot(WEAPON_NINJA)?"You can't use /pause while you are a ninja":(!pChr->IsGrounded())?"You can't use /pause while you are a in air":"You can't use /pause while you are moving");
 		else if(pPlayer->m_ForcePauseTime > 0)
 		{
 			str_format(aBuf, sizeof(aBuf), "You have been force-paused. %ds left.", pPlayer->m_ForcePauseTime/pSelf->Server()->TickSpeed());
@@ -524,8 +524,8 @@ void CGameContext::ConForcePause(IConsole::IResult *pResult, void *pUserData, in
 	if(!pPlayer->GetTeam() && pChr && !pPlayer->m_InfoSaved)
 	{
 		pPlayer->SaveCharacter();
-		pPlayer->SetTeam(TEAM_SPECTATORS);
 		pPlayer->m_InfoSaved = true;
+		pPlayer->SetTeam(TEAM_SPECTATORS);
 		pPlayer->m_ForcePauseTime = Seconds*pServ->TickSpeed();
 	}
 	else
@@ -552,9 +552,9 @@ void CGameContext::ConForceUnpause(IConsole::IResult *pResult, void *pUserData, 
 
 	if(pPlayer->GetTeam()==TEAM_SPECTATORS && pPlayer->m_InfoSaved)
 	{
-		pPlayer->m_InfoSaved = false;
 		pPlayer->m_PauseInfo.m_Respawn = true;
 		pPlayer->SetTeam(TEAM_RED);
+		pPlayer->m_InfoSaved = false;
 		//pPlayer->LoadCharacter();//TODO:Check if this system Works
 		pPlayer->m_ForcePauseTime = 0;
 	}
@@ -696,14 +696,19 @@ void CGameContext::ConJoinTeam(IConsole::IResult *pResult, void *pUserData, int 
 	else
 	{
 		char aBuf[512];
-		if(pPlayer->GetCharacter() == 0)
-		{
-			pResult->Print(IConsole::OUTPUT_LEVEL_STANDARD, "info", "You can't check your team while you are dead/a spectator.");
-		}
-		else
+		if(pPlayer->GetCharacter())
 		{
 			str_format(aBuf, sizeof(aBuf), "You are in team %d", pPlayer->GetCharacter()->Team());
 			pResult->Print(IConsole::OUTPUT_LEVEL_STANDARD, "info", aBuf);
+		}
+		else if(pPlayer->m_InfoSaved)
+		{
+			str_format(aBuf, sizeof(aBuf), "You are in team %d", pPlayer->m_PauseInfo.m_Team);
+			pResult->Print(IConsole::OUTPUT_LEVEL_STANDARD, "info", aBuf);
+		}
+		else
+		{
+			pResult->Print(IConsole::OUTPUT_LEVEL_STANDARD, "info", "You can't check your team while you are dead/a spectator.");
 		}
 	}
 }

--- a/src/game/server/ddracecommands.cpp
+++ b/src/game/server/ddracecommands.cpp
@@ -458,6 +458,7 @@ void CGameContext::ConKill(IConsole::IResult *pResult, void *pUserData, int Clie
 void CGameContext::ConTogglePause(IConsole::IResult *pResult, void *pUserData, int ClientID)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
+	char aBuf[128];
 
 	CPlayer *pPlayer = pSelf->m_apPlayers[ClientID];
 	if(!pPlayer)
@@ -477,7 +478,7 @@ void CGameContext::ConTogglePause(IConsole::IResult *pResult, void *pUserData, i
 			else
 				pResult->Print(IConsole::OUTPUT_LEVEL_STANDARD, "info", "You can\'t pause that often.");
 		}
-		else if(pPlayer->GetTeam()==TEAM_SPECTATORS && pPlayer->m_InfoSaved)
+		else if(pPlayer->GetTeam()==TEAM_SPECTATORS && pPlayer->m_InfoSaved && pPlayer->m_ForcePauseTime==0)
 		{
 			pPlayer->m_InfoSaved = false;
 			pPlayer->m_PauseInfo.m_Respawn = true;
@@ -486,11 +487,86 @@ void CGameContext::ConTogglePause(IConsole::IResult *pResult, void *pUserData, i
 		}
 		else if(pChr)
 			pResult->Print(IConsole::OUTPUT_LEVEL_STANDARD, "info", (pChr->Team())?"You can't pause while you are in a team":pChr->GetWeaponGot(WEAPON_NINJA)?"You can't use /pause while you are a ninja":(!pChr->IsGrounded())?"You can't use /pause while you are a in air":"You can't use /pause while you are moving");
+		else if(pPlayer->m_ForcePauseTime > 0)
+		{
+			str_format(aBuf, sizeof(aBuf), "You have been force-paused. %ds left.", pPlayer->m_ForcePauseTime/pSelf->Server()->TickSpeed());
+			pResult->Print(IConsole::OUTPUT_LEVEL_STANDARD, "info", aBuf);
+		}
+		else if(pPlayer->m_ForcePauseTime < 0)
+		{
+			pResult->Print(IConsole::OUTPUT_LEVEL_STANDARD, "info", "You have been force-paused.");
+		}
 		else
 			pResult->Print(IConsole::OUTPUT_LEVEL_STANDARD, "info", "No pause data saved.");
 	}
 	else
 		pResult->Print(IConsole::OUTPUT_LEVEL_STANDARD, "info", "Pause isn't allowed on this server.");
+}
+
+void CGameContext::ConForcePause(IConsole::IResult *pResult, void *pUserData, int ClientID)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	CServer* pServ = (CServer*)pSelf->Server();
+	int Victim = pResult->GetVictim();
+	int Seconds;
+	char aBuf[128];
+
+	if(pResult->NumArguments() > 0)
+		Seconds = pResult->GetInteger(0);
+	else
+		Seconds = g_Config.m_SvVotePauseTime;
+
+	CPlayer *pPlayer = pSelf->m_apPlayers[Victim];
+	if(!pPlayer)
+		return;
+
+	CCharacter* pChr = pPlayer->GetCharacter();
+	if(!pPlayer->GetTeam() && pChr && !pPlayer->m_InfoSaved)
+	{
+		pPlayer->SaveCharacter();
+		pPlayer->SetTeam(TEAM_SPECTATORS);
+		pPlayer->m_InfoSaved = true;
+		pPlayer->m_ForcePauseTime = Seconds*pServ->TickSpeed();
+	}
+	else
+	{
+		pPlayer->m_ForcePauseTime = Seconds*pServ->TickSpeed();
+	}
+	if(ClientID < 0)
+		str_format(aBuf, sizeof(aBuf), "'%s' has been force-paused for %d seconds", pServ->ClientName(Victim), Seconds);
+	else
+		str_format(aBuf, sizeof(aBuf), "'%s' has been force-paused for %d seconds by '%s'", pServ->ClientName(Victim), Seconds, pServ->ClientName(ClientID));
+	pSelf->SendChat(-1, CHAT_ALL, aBuf);
+}
+
+void CGameContext::ConForceUnpause(IConsole::IResult *pResult, void *pUserData, int ClientID)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	CServer* pServ = (CServer*)pSelf->Server();
+	int Victim = pResult->GetVictim();
+	char aBuf[128];
+
+	CPlayer *pPlayer = pSelf->m_apPlayers[Victim];
+	if(!pPlayer)
+		return;
+
+	if(pPlayer->GetTeam()==TEAM_SPECTATORS && pPlayer->m_InfoSaved)
+	{
+		pPlayer->m_InfoSaved = false;
+		pPlayer->m_PauseInfo.m_Respawn = true;
+		pPlayer->SetTeam(TEAM_RED);
+		//pPlayer->LoadCharacter();//TODO:Check if this system Works
+		pPlayer->m_ForcePauseTime = 0;
+	}
+	else // Shouldn't be reached
+	{
+		pPlayer->m_ForcePauseTime = 0;
+	}
+	if(ClientID < 0)
+		str_format(aBuf, sizeof(aBuf), "'%s' has been force-unpaused", pServ->ClientName(Victim));
+	else
+		str_format(aBuf, sizeof(aBuf), "'%s' has been force-unpaused by '%s'", pServ->ClientName(Victim), pServ->ClientName(ClientID));
+	pSelf->SendChat(-1, CHAT_ALL, aBuf);
 }
 
 void CGameContext::ConTop5(IConsole::IResult *pResult, void *pUserData, int ClientID)

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -942,9 +942,18 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 				return;
 			}
 
-			str_format(aChatmsg, sizeof(aChatmsg), "'%s' called for vote to move '%s' to spectators (%s)", Server()->ClientName(ClientID), Server()->ClientName(SpectateID), pReason);
-			str_format(aDesc, sizeof(aDesc), "move '%s' to spectators", Server()->ClientName(SpectateID));
-			str_format(aCmd, sizeof(aCmd), "set_team %d -1", SpectateID);
+			if(g_Config.m_SvPauseable && g_Config.m_SvVotePause)
+			{
+				str_format(aChatmsg, sizeof(aChatmsg), "'%s' called for vote to pause '%s' for %d seconds (%s)", Server()->ClientName(ClientID), Server()->ClientName(SpectateID), g_Config.m_SvVotePauseTime, pReason);
+				str_format(aDesc, sizeof(aDesc), "Pause '%s' (%ds)", Server()->ClientName(SpectateID),  g_Config.m_SvVotePauseTime);
+				str_format(aCmd, sizeof(aCmd), "force_pause %d", SpectateID);
+			}
+			else
+			{
+				str_format(aChatmsg, sizeof(aChatmsg), "'%s' called for vote to move '%s' to spectators (%s)", Server()->ClientName(ClientID), Server()->ClientName(SpectateID), pReason);
+				str_format(aDesc, sizeof(aDesc), "move '%s' to spectators", Server()->ClientName(SpectateID));
+				str_format(aCmd, sizeof(aCmd), "set_team %d -1", SpectateID);
+			}
 		}
 
 		if(aCmd[0])

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -218,6 +218,8 @@ private:
 	static void ConRules(IConsole::IResult *pResult, void *pUserData, int ClientID);
 	static void ConKill(IConsole::IResult *pResult, void *pUserData, int ClientID);
 	static void ConTogglePause(IConsole::IResult *pResult, void *pUserData, int ClientID);
+	static void ConForcePause(IConsole::IResult *pResult, void *pUserData, int ClientID);
+	static void ConForceUnpause(IConsole::IResult *pResult, void *pUserData, int ClientID);
 	static void ConTop5(IConsole::IResult *pResult, void *pUserData, int ClientID);
 	#if defined(CONF_SQL)
 	static void ConTimes(IConsole::IResult *pResult, void *pUserData, int ClientID);

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -64,6 +64,16 @@ void CPlayer::Tick()
 	if (m_ChatScore > 0)
 		m_ChatScore--;
 
+	if (g_Config.m_SvVotePauseAuto && m_ForcePauseTime==1 && GetTeam()==TEAM_SPECTATORS && m_InfoSaved)
+	{
+		m_InfoSaved = false;
+		m_PauseInfo.m_Respawn = true;
+		SetTeam(TEAM_RED);
+	}
+
+	if (m_ForcePauseTime > 0)
+		m_ForcePauseTime--;
+
 	Server()->SetClientScore(m_ClientID, m_Score);
 
 	// do latency stuff

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -277,7 +277,15 @@ void CPlayer::SetTeam(int Team)
 		return;
 
 	char aBuf[512];
-	str_format(aBuf, sizeof(aBuf), "'%s' joined the %s", Server()->ClientName(m_ClientID), GameServer()->m_pController->GetTeamName(Team));
+	if(m_InfoSaved)
+	{
+		if(Team == TEAM_SPECTATORS)
+			str_format(aBuf, sizeof(aBuf), "'%s' paused", Server()->ClientName(m_ClientID));
+		else
+			str_format(aBuf, sizeof(aBuf), "'%s' resumed", Server()->ClientName(m_ClientID));
+	}
+	else
+		str_format(aBuf, sizeof(aBuf), "'%s' joined the %s", Server()->ClientName(m_ClientID), GameServer()->m_pController->GetTeamName(Team));
 	GameServer()->SendChat(-1, CGameContext::CHAT_ALL, aBuf);
 
 	KillCharacter();

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -132,6 +132,7 @@ public:
 		int m_Team;
 		int m_TeleCheckpoint;
 	} m_PauseInfo;
+	int m_ForcePauseTime;
 	bool m_InfoSaved;
 	void LoadCharacter();
 	void SaveCharacter();

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -149,11 +149,18 @@ void CGameTeams::SetForceCharacterTeam(int ClientID, int Team)
 	{
 		bool NoOneInOldTeam = true;
 		for(int i = 0; i < MAX_CLIENTS; ++i)
+		{
 			if(i != ClientID && m_Core.Team(ClientID) == m_Core.Team(i))
 			{
 				NoOneInOldTeam = false;//all good exists someone in old team
 				break;
-			} 
+			}
+			else if(GameServer()->m_apPlayers[i] && GameServer()->m_apPlayers[i]->m_InfoSaved && GameServer()->m_apPlayers[i]->m_PauseInfo.m_Team == m_Core.Team(ClientID))
+			{
+				NoOneInOldTeam = false;//all good exists someone in old team
+				break;
+			}
+		}
 		if(NoOneInOldTeam)
 			m_TeamState[m_Core.Team(ClientID)] = TEAMSTATE_EMPTY;
 	}
@@ -185,8 +192,12 @@ void CGameTeams::ChangeTeamState(int Team, int State)
 bool CGameTeams::TeamFinished(int Team)
 {
 	for(int i = 0; i < MAX_CLIENTS; ++i)
+	{
 		if(m_Core.Team(i) == Team && !m_TeeFinished[i])
 			return false;
+		if(GameServer()->m_apPlayers[i] && GameServer()->m_apPlayers[i]->m_InfoSaved && GameServer()->m_apPlayers[i]->m_PauseInfo.m_Team == Team && !m_TeeFinished[i])
+			return false;
+	}
 	return true;
 }
 

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -78,6 +78,9 @@ MACRO_CONFIG_INT(SvVoteKick, sv_vote_kick, 1, 0, 1, CFGFLAG_SERVER, "Allow votin
 MACRO_CONFIG_INT(SvVoteKickMin, sv_vote_kick_min, 0, 0, MAX_CLIENTS, CFGFLAG_SERVER, "Minimum number of players required to start a kick vote", IConsole::CONSOLELEVEL_ADMIN)
 MACRO_CONFIG_INT(SvVoteKickBantime, sv_vote_kick_bantime, 5, 0, 1440, CFGFLAG_SERVER, "The time to ban a player if kicked by vote. 0 makes it just use kick", IConsole::CONSOLELEVEL_ADMIN)
 
+MACRO_CONFIG_INT(SvVotePause, sv_vote_pause, 1, 0, 1, CFGFLAG_SERVER, "Allow voting to pause players (instead of moving to spectators)", IConsole::CONSOLELEVEL_ADMIN)
+MACRO_CONFIG_INT(SvVotePauseTime, sv_vote_pause_time, 60, 0, 3600, CFGFLAG_SERVER, "The time (in seconds) players have to wait in pause when paused by vote", IConsole::CONSOLELEVEL_ADMIN)
+MACRO_CONFIG_INT(SvVotePauseAuto, sv_vote_pause_auto, 1, 0, 1, CFGFLAG_SERVER, "Automatically unpaused players after the force-pause delay or not", IConsole::CONSOLELEVEL_ADMIN)
 // debug
 #ifdef CONF_DEBUG // this one can crash the server if not used correctly
 	MACRO_CONFIG_INT(DbgDummies, dbg_dummies, 0, 0, 15, CFGFLAG_SERVER, "", IConsole::CONSOLELEVEL_ADMIN)


### PR DESCRIPTION
This add the following config variables :
*sv_vote_pause: Allow voting to pause players (instead of moving to spectators) (default: 1)
*sv_vote_pause_time: The time (in seconds) players have to wait in pause when paused by vote (default: 60)
*sv_vote_pause_auto: Automatically unpaused players after the force-pause delay or not (default: 1)

And these functions :
- force_pause v?i : Force v to pause for i seconds
- force_unpause v : Force v to unpause
