### PR TITLE
Fixed obligatory Teams (sv_team 2).

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -501,6 +501,8 @@ void CGameContext::ConJoinTeam(IConsole::IResult *pResult, void *pUserData)
 	if (!CheckClientID(pResult->m_ClientID))
 		return;
 
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+
 	if (pSelf->m_VoteCloseTime && pSelf->m_VoteCreator == pResult->m_ClientID)
 	{
 		pSelf->Console()->Print(
@@ -515,14 +517,14 @@ void CGameContext::ConJoinTeam(IConsole::IResult *pResult, void *pUserData)
 				"Admin has disabled teams");
 		return;
 	}
-	else if (g_Config.m_SvTeam == 2)
+	else if (g_Config.m_SvTeam == 2 && pResult->GetInteger(0) == 0 && pPlayer->GetCharacter()->m_LastStartWarning < pSelf->Server()->Tick() - 3 * pSelf->Server()->TickSpeed())
 	{
 		pSelf->Console()->Print(
 				IConsole::OUTPUT_LEVEL_STANDARD,
 				"join",
-				"You must join to any team and play with anybody or you will not play");
+				"You must join a team and play with somebody or else you can\'t play");
+		pPlayer->GetCharacter()->m_LastStartWarning = pSelf->Server()->Tick();
 	}
-	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
 
 	if (pResult->NumArguments() > 0)
 	{
@@ -539,7 +541,7 @@ void CGameContext::ConJoinTeam(IConsole::IResult *pResult, void *pUserData)
 					> pSelf->Server()->Tick())
 			{
 				pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "join",
-						"You can\'t join teams that fast!");
+						"You can\'t change teams that fast!");
 			}
 			else if (((CGameControllerDDRace*) pSelf->m_pController)->m_Teams.SetCharacterTeam(
 					pPlayer->GetCID(), pResult->GetInteger(0)))

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1242,6 +1242,7 @@ void CCharacter::HandleTiles(int Index)
 				GameServer()->SendChatTarget(GetPlayer()->GetCID(),"Server admin requires you to be in a team and with other tees to start");
 				m_LastStartWarning = Server()->Tick();
 			}
+			Die(GetPlayer()->GetCID(), WEAPON_WORLD);
 			CanBegin = false;
 		}
 		if(CanBegin)


### PR DESCRIPTION
Obligatory teams were allowing cheat. Start tile should kill when sv_team == 2 and players team = 0
