### PR TITLE
turns out that Drop was needed after all :S

### DIFF
--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -232,7 +232,7 @@ int CNetServer::Send(CNetChunk *pChunk)
 		}
 		else
 		{
-//			Drop(pChunk->m_ClientID, "Error sending data");
+			Drop(pChunk->m_ClientID, "Error sending data");
 		}
 	}
 	return 0;


### PR DESCRIPTION
uncommented drop()
changed map chunks to non-vital msgs (server wont buffer them for resend now)
implemented a download stall detection
