### PR TITLE
Restricting rcon output to player

### DIFF
--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -70,6 +70,7 @@ public:
 	// DDRace
 
 	virtual void GetClientAddr(int ClientID, NETADDR *pAddr) = 0;
+	virtual void RestrictRconOutput(int ClientID) = 0;
 };
 
 class IGameServer : public IInterface

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -312,6 +312,8 @@ CServer::CServer() : m_DemoRecorder(&m_SnapshotDelta)
 	m_RconClientID = IServer::RCON_CID_SERV;
 	m_RconAuthLevel = AUTHED_ADMIN;
 
+	m_RconRestrict = -1;
+
 	Init();
 }
 
@@ -788,7 +790,7 @@ void CServer::SendRconLineAuthed(const char *pLine, void *pUser)
 
 	for(i = 0; i < MAX_CLIENTS; i++)
 	{
-		if(pThis->m_aClients[i].m_State != CClient::STATE_EMPTY && pThis->m_aClients[i].m_Authed >= pThis->m_RconAuthLevel)
+		if(pThis->m_aClients[i].m_State != CClient::STATE_EMPTY && pThis->m_aClients[i].m_Authed >= pThis->m_RconAuthLevel && (pThis->m_RconRestrict == -1 || pThis->m_RconRestrict == i))
 			pThis->SendRconLine(i, pLine);
 	}
 

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -312,7 +312,7 @@ CServer::CServer() : m_DemoRecorder(&m_SnapshotDelta)
 	m_RconClientID = IServer::RCON_CID_SERV;
 	m_RconAuthLevel = AUTHED_ADMIN;
 
-	m_RconRestrict = -1;
+	m_RconOutputRestrict = -1;
 
 	Init();
 }
@@ -790,7 +790,7 @@ void CServer::SendRconLineAuthed(const char *pLine, void *pUser)
 
 	for(i = 0; i < MAX_CLIENTS; i++)
 	{
-		if(pThis->m_aClients[i].m_State != CClient::STATE_EMPTY && pThis->m_aClients[i].m_Authed >= pThis->m_RconAuthLevel && (pThis->m_RconRestrict == -1 || pThis->m_RconRestrict == i))
+		if(pThis->m_aClients[i].m_State != CClient::STATE_EMPTY && pThis->m_aClients[i].m_Authed >= pThis->m_RconAuthLevel && (pThis->m_RconOutputRestrict == -1 || pThis->m_RconOutputRestrict == i))
 			pThis->SendRconLine(i, pLine);
 	}
 
@@ -1018,7 +1018,9 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 				m_RconClientID = ClientID;
 				m_RconAuthLevel = m_aClients[ClientID].m_Authed;
 				Console()->SetAccessLevel(m_aClients[ClientID].m_Authed == AUTHED_ADMIN ? IConsole::ACCESS_LEVEL_ADMIN : m_aClients[ClientID].m_Authed == AUTHED_MOD ? IConsole::ACCESS_LEVEL_MOD : IConsole::ACCESS_LEVEL_USER);
+				RestrictRconOutput(ClientID);
 				Console()->ExecuteLineFlag(pCmd, CFGFLAG_SERVER, ClientID);
+				RestrictRconOutput(-1);
 				Console()->SetAccessLevel(IConsole::ACCESS_LEVEL_ADMIN);
 				m_RconClientID = IServer::RCON_CID_SERV;
 				m_RconAuthLevel = AUTHED_ADMIN;

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -169,7 +169,7 @@ public:
 	CRegister m_Register;
 	CMapChecker m_MapChecker;
 
-	int m_RconRestrict;
+	int m_RconOutputRestrict;
 
 	CServer();
 
@@ -257,7 +257,7 @@ public:
 	int m_aPrevStates[MAX_CLIENTS];
 	char *GetAnnouncementLine(char const *FileName);
 	unsigned m_AnnouncementLastLine;
-	void RestrictRconOutput(int ClientID) { m_RconRestrict = ClientID; }
+	void RestrictRconOutput(int ClientID) { m_RconOutputRestrict = ClientID; }
 };
 
 #endif

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -169,6 +169,8 @@ public:
 	CRegister m_Register;
 	CMapChecker m_MapChecker;
 
+	int m_RconRestrict;
+
 	CServer();
 
 	int TrySetClientName(int ClientID, const char *pName);
@@ -255,6 +257,7 @@ public:
 	int m_aPrevStates[MAX_CLIENTS];
 	char *GetAnnouncementLine(char const *FileName);
 	unsigned m_AnnouncementLastLine;
+	void RestrictRconOutput(int ClientID) { m_RconRestrict = ClientID; }
 };
 
 #endif

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -805,6 +805,7 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 		if(pMsg->m_pMessage[0]=='/')
 		{
 			m_ChatResponseTargetID = ClientID;
+			Server()->RestrictRconOutput(ClientID);
 			Console()->SetFlagMask(CFGFLAG_CHAT);
 
 			if (pPlayer->m_Authed)
@@ -821,6 +822,7 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 			Console()->SetAccessLevel(IConsole::ACCESS_LEVEL_ADMIN);
 			Console()->SetFlagMask(CFGFLAG_SERVER);
 			m_ChatResponseTargetID = -1;
+			Server()->RestrictRconOutput(-1);
 		}
 		else
 			SendChat(ClientID, Team, pMsg->m_pMessage, ClientID);


### PR DESCRIPTION
Since all chat commands use OUTPUT_LEVEL_STANDARD for printing the output gets displayed in every remote console. Without spamprotection this issue can be used to kick authed players out of the server (https://github.com/DDRace/teeworlds/issues/232).
Here I added a functionality to restrict output messages to specific players. This workaround might be ugly but the ddrace command system kinda lacks of design
