### PR TITLE
Only allow voting team members to spectators to prevent abuse

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1011,6 +1011,12 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 				return;
 			}
 
+			if(GetPlayerChar(ClientID) && GetPlayerChar(SpectateID) && GetDDRaceTeam(ClientID) != GetDDRaceTeam(SpectateID))
+			{
+				SendChatTarget(ClientID, "You can only move your team member to specators");
+				return;
+			}
+
 			if(g_Config.m_SvPauseable && g_Config.m_SvVotePause)
 			{
 				str_format(aChatmsg, sizeof(aChatmsg), "'%s' called for vote to pause '%s' for %d seconds (%s)", Server()->ClientName(ClientID), Server()->ClientName(SpectateID), g_Config.m_SvVotePauseTime, pReason);

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -971,7 +971,8 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 				return;
 			}
 
-			if(GetPlayerChar(ClientID) && GetPlayerChar(KickID) && GetDDRaceTeam(ClientID) != GetDDRaceTeam(KickID))
+			// Don't allow kicking if a player has no character
+			if(!GetPlayerChar(ClientID) || !GetPlayerChar(KickID) || GetDDRaceTeam(ClientID) != GetDDRaceTeam(KickID))
 			{
 				SendChatTarget(ClientID, "You can kick only your team member");
 				m_apPlayers[ClientID]->m_Last_KickVote = time_get();
@@ -1011,7 +1012,7 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 				return;
 			}
 
-			if(GetPlayerChar(ClientID) && GetPlayerChar(SpectateID) && GetDDRaceTeam(ClientID) != GetDDRaceTeam(SpectateID))
+			if(!GetPlayerChar(ClientID) || GetPlayerChar(SpectateID) || GetDDRaceTeam(ClientID) != GetDDRaceTeam(SpectateID))
 			{
 				SendChatTarget(ClientID, "You can only move your team member to specators");
 				return;


### PR DESCRIPTION
Someone can simply join an empty team and vote another player from another team to specators. This commit should fix this.

There might be other bugs in the spectator voting, but I'm not sure.
